### PR TITLE
Fixed Dockerfile entrypoint to use the script instead of pure bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ RUN mkdir -p /etc/excludarr
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["bash"]
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
As stated on issue #20 , on Docker the app doesn't work.

Checking, the Dockerfile was using entrypoint "bash" instead of the "/entrypoint.sh" needed for the app.